### PR TITLE
Compile `wg` utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ vintage_net_wireguard-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+/dl/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+# Makefile for building port binaries
+#
+# Makefile targets:
+#
+# all					  build the wg binary
+# clean         clean build products and intermediates
+#
+# Variables to override:
+#
+# MIX_APP_PATH  path to the build directory
+#
+# CC            C compiler
+# CROSSCOMPILE	crosscompiler prefix, if any
+# CFLAGS	compiler flags for compiling all C files
+# ERL_CFLAGS	additional compiler flags for files using Erlang header files
+# ERL_EI_INCLUDE_DIR include path to ei.h (Required for crosscompile)
+# ERL_EI_LIBDIR path to libei.a (Required for crosscompile)
+# LDFLAGS	linker flags for linking all binaries
+# ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
+#
+ifeq ($(MIX_APP_PATH),)
+calling_from_make:
+	mix compile
+endif
+
+PREFIX = $(MIX_APP_PATH)/priv
+BUILD  = $(MIX_APP_PATH)/obj
+
+TOP := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+DL = $(TOP)/dl
+
+TOOLS_VER = v1.0.20210914
+TOOLS = $(DL)/wireguard-tools-$(TOOLS_VER)
+
+# Disable unneeded Wireguard features
+# see https://git.zx2c4.com/wireguard-tools/about/
+MAKE_ENV += WITH_SYSTEMDUNITS=no WITH_BASHCOMPLETION=no WITH_WGQUICK=no
+
+# Let Wireguard Makefile determine platform if we are
+# compiling for the host platform
+ifneq ($(TARGET_OS),)
+MAKE_ENV += PLATFORM=$(TARGET_OS)
+endif
+
+# This is needed until https://github.com/nerves-project/nerves/issues/705 is fixed
+TARGET_ARCH=
+
+all: $(BUILD) $(PREFIX) $(TOOLS) $(PREFIX)/wg
+
+$(BUILD)/Makefile: $(TOOLS)
+	cp -R $(TOOLS)/src/* $(BUILD)/
+
+$(PREFIX)/wg: $(BUILD)/Makefile
+	$(MAKE_ENV) $(MAKE) -C $(BUILD) -j$(shell nproc)
+	@install -m 0755 $(BUILD)/wg $(PREFIX)/wg
+
+$(PREFIX) $(BUILD) $(DL):
+	mkdir -p $@
+
+$(TOOLS): $(DL)
+	@echo "  DL      $(notdir $@)"
+	git clone --branch $(TOOLS_VER) https://git.zx2c4.com/wireguard-tools $@ 2>/dev/null
+
+mix_clean:
+	rm -rf $(BUILD) $(PREFIX)
+
+clean: 
+	mix clean
+
+# Don't echo commands unless the caller exports "V=1"
+${V}.SILENT:

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule VintageNetWireguard.MixProject do
       app: :vintage_net_wireguard,
       version: "0.1.0",
       elixir: "~> 1.13",
+      compilers: [:elixir_make | Mix.compilers()],
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
@@ -19,6 +20,7 @@ defmodule VintageNetWireguard.MixProject do
 
   defp deps do
     [
+      {:elixir_make, "~> 0.6", runtime: false},
       {:vintage_net, "~> 0.11"}
     ]
   end


### PR DESCRIPTION
This currently assumes `linux` is the platform and skips using the wireguard Makefile in order to put build objects in the `_build` directory with the app build. 

There might be a way to do that using their Makefile that I just haven't discovered yet and this gets things moving