### PR TITLE
Fix the return value of 'ConfigFile.parse' in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ process and `VintageNetWireguard` provides a helper function to parse those
 config files into the expected format:
 
 ```elixir
-iex)> {:ok, config} = VintageNetWireguard.ConfigFile.parse("/path/to/wg0.conf")
+iex)> config = VintageNetWireguard.ConfigFile.parse("/path/to/wg0.conf")
 iex)> VintageNet.configure("wg0", config)
 ```
 <!--- DOC !--->


### PR DESCRIPTION
This PR updates the example in the readme to match the return value of the `ConfigFile.parse` function.

https://github.com/nerves-networking/vintage_net_wireguard/blob/51ddc33e4b51a7442df1e71c765f2d51dc7ca1a8/lib/vintage_net_wireguard/config_file.ex#L9

-----

Considering the `parse` function can return an error tuple, it could be that the readme is correct and the function should return `{:ok, config}` instead of just `config`. If this is the case, I could make that update instead.