### PR TITLE
Ensure peer arg ordering is correct 

### DIFF
--- a/lib/vintage_net_wireguard.ex
+++ b/lib/vintage_net_wireguard.ex
@@ -86,7 +86,7 @@ defmodule VintageNetWireguard do
   defp normalize_fwmark(%{fwmark: fwmark} = config) when is_integer(fwmark), do: config
 
   defp normalize_fwmark(%{fwmark: fwmark} = config) do
-    Logger.warning("Ignoring invalid Wireguard FwMark: #{inspect(fwmark)}")
+    Logger.warning("[VintageNetWireguard] Ignoring invalid FwMark: #{inspect(fwmark)}")
     Map.delete(config, :fwmark)
   end
 
@@ -95,7 +95,7 @@ defmodule VintageNetWireguard do
   defp normalize_listen_port(%{listen_port: port} = config) when is_integer(port), do: config
 
   defp normalize_listen_port(%{listen_port: port} = config) do
-    Logger.warning("Ignoring invalid Wireguard ListenPort: #{inspect(port)}")
+    Logger.warning("[VintageNetWireguard] Ignoring invalid ListenPort: #{inspect(port)}")
     Map.delete(config, :listen_port)
   end
 
@@ -107,7 +107,7 @@ defmodule VintageNetWireguard do
   end
 
   defp normalize_dns(%{dns: dns} = config) do
-    Logger.warning("Ignoring invalid Wireguard DNS: #{inspect(dns)}")
+    Logger.warning("[VintageNetWireguard] Ignoring invalid DNS: #{inspect(dns)}")
     Map.delete(config, :dns)
   end
 
@@ -125,7 +125,10 @@ defmodule VintageNetWireguard do
   defp normalize_keepalive(%{persistent_keepalive: pk} = peer) when pk in 0..65535, do: peer
 
   defp normalize_keepalive(%{persistent_keepalive: pk} = peer) do
-    Logger.warning("Ignoring invalid Wireguard peer PersistentKeepalive: #{inspect(pk)}")
+    Logger.warning(
+      "[VintageNetWireguard] Ignoring invalid peer PersistentKeepalive: #{inspect(pk)}"
+    )
+
     Map.delete(peer, :persistent_keepalive)
   end
 
@@ -135,7 +138,7 @@ defmodule VintageNetWireguard do
     do: peer
 
   defp normalize_preshared_key(%{preshared_key: psk} = peer) do
-    Logger.warning("Ignoring invalid Wireguard peer PresharedKey: #{inspect(psk)}")
+    Logger.warning("[VintageNetWireguard] Ignoring invalid peer PresharedKey: #{inspect(psk)}")
     Map.delete(peer, :preshared_key)
   end
 
@@ -216,7 +219,7 @@ defmodule VintageNetWireguard do
     else
       err ->
         Temp.cleanup()
-        {:error, "Failed to set Wireguard interface - #{inspect(err)}"}
+        {:error, "[VintageNetWireguard] Failed to set interface - #{inspect(err)}"}
     end
   end
 
@@ -248,7 +251,7 @@ defmodule VintageNetWireguard do
     else
       {err, s} ->
         Logger.error("""
-        Nonzero exit setting peer: #{s}
+        [VintageNetWireguard] Nonzero exit setting peer: #{s}
 
         #{inspect(err)}
         """)

--- a/lib/vintage_net_wireguard.ex
+++ b/lib/vintage_net_wireguard.ex
@@ -240,7 +240,8 @@ defmodule VintageNetWireguard do
 
   defp set_peer(ifname, peer) do
     with {:ok, tracker} <- Temp.track(),
-         peer_args = Enum.reduce(peer, [], &add_peer_arg/2),
+         # peer arg needs to be first
+         peer_args = ["peer", peer.public_key | Enum.reduce(peer, [], &add_peer_arg/2)],
          {_, 0} <- System.cmd(wg(), ["set", ifname | peer_args]) do
       _ = Temp.cleanup(tracker)
       :ok
@@ -271,7 +272,6 @@ defmodule VintageNetWireguard do
     ["preshared-key", path | acc]
   end
 
-  defp add_peer_arg({:public_key, v}, acc), do: ["peer", v | acc]
   defp add_peer_arg(_, acc), do: acc
 
   defp addr_subnet({ip, prefix_len}) do

--- a/lib/vintage_net_wireguard.ex
+++ b/lib/vintage_net_wireguard.ex
@@ -210,7 +210,7 @@ defmodule VintageNetWireguard do
   defp set_wg_interface(ifname, config) do
     with {:ok, tracker} <- Temp.track(),
          if_args = Enum.reduce(config, [], &add_if_arg/2),
-         {_, 0} <- System.cmd(wg(), ["set", ifname | if_args]),
+         {_, 0} <- System.cmd(wg(), ["set", ifname | if_args], stderr_to_stdout: true),
          [_ | _] <- Temp.cleanup(tracker) do
       :ok
     else
@@ -242,7 +242,7 @@ defmodule VintageNetWireguard do
     with {:ok, tracker} <- Temp.track(),
          # peer arg needs to be first
          peer_args = ["peer", peer.public_key | Enum.reduce(peer, [], &add_peer_arg/2)],
-         {_, 0} <- System.cmd(wg(), ["set", ifname | peer_args]) do
+         {_, 0} <- System.cmd(wg(), ["set", ifname | peer_args], stderr_to_stdout: true) do
       _ = Temp.cleanup(tracker)
       :ok
     else


### PR DESCRIPTION
Fixes #11

With OTP 26, map orderings were slightly changed. This made one of the arguments
become out of order when setting a peer up with `wg`.

This change enforces that expected order now

Also adds a few cleanup commits:
* Print stderr_to_stdout with wg commands
* Scope logger messages to module