### PR TITLE
change allowed-ips separator to comma

### DIFF
--- a/lib/vintage_net_wireguard.ex
+++ b/lib/vintage_net_wireguard.ex
@@ -195,7 +195,7 @@ defmodule VintageNetWireguard do
   end
 
   defp maybe_add_interface(ifname) do
-    case System.cmd("ip", ["link", "show", ifname]) do
+    case System.cmd("ip", ["link", "show", ifname], stderr_to_stdout: true) do
       {_, 0} -> []
       _ -> {:run_ignore_errors, "ip", ["link", "add", ifname, "type", "wireguard"]}
     end
@@ -210,7 +210,7 @@ defmodule VintageNetWireguard do
   defp set_wg_interface(ifname, config) do
     with {:ok, tracker} <- Temp.track(),
          if_args = Enum.reduce(config, [], &add_if_arg/2),
-         {_, 0} <- System.cmd(wg(), ["set", ifname | if_args]),
+         {_, 0} <- System.cmd(wg(), ["set", ifname | if_args], stderr_to_stdout: true),
          [_ | _] <- Temp.cleanup(tracker) do
       :ok
     else
@@ -242,7 +242,7 @@ defmodule VintageNetWireguard do
     with {:ok, tracker} <- Temp.track(),
          # peer arg needs to be first
          peer_args = ["peer", peer.public_key | Enum.reduce(peer, [], &add_peer_arg/2)],
-         {_, 0} <- System.cmd(wg(), ["set", ifname | peer_args]) do
+         {_, 0} <- System.cmd(wg(), ["set", ifname | peer_args], stderr_to_stdout: true) do
       _ = Temp.cleanup(tracker)
       :ok
     else

--- a/lib/vintage_net_wireguard.ex
+++ b/lib/vintage_net_wireguard.ex
@@ -86,7 +86,7 @@ defmodule VintageNetWireguard do
   defp normalize_fwmark(%{fwmark: fwmark} = config) when is_integer(fwmark), do: config
 
   defp normalize_fwmark(%{fwmark: fwmark} = config) do
-    Logger.warning("Ignoring invalid Wireguard FwMark: #{inspect(fwmark)}")
+    Logger.warning("[VintageNetWireguard] Ignoring invalid FwMark: #{inspect(fwmark)}")
     Map.delete(config, :fwmark)
   end
 
@@ -95,7 +95,7 @@ defmodule VintageNetWireguard do
   defp normalize_listen_port(%{listen_port: port} = config) when is_integer(port), do: config
 
   defp normalize_listen_port(%{listen_port: port} = config) do
-    Logger.warning("Ignoring invalid Wireguard ListenPort: #{inspect(port)}")
+    Logger.warning("[VintageNetWireguard] Ignoring invalid ListenPort: #{inspect(port)}")
     Map.delete(config, :listen_port)
   end
 
@@ -107,7 +107,7 @@ defmodule VintageNetWireguard do
   end
 
   defp normalize_dns(%{dns: dns} = config) do
-    Logger.warning("Ignoring invalid Wireguard DNS: #{inspect(dns)}")
+    Logger.warning("[VintageNetWireguard] Ignoring invalid DNS: #{inspect(dns)}")
     Map.delete(config, :dns)
   end
 
@@ -125,7 +125,10 @@ defmodule VintageNetWireguard do
   defp normalize_keepalive(%{persistent_keepalive: pk} = peer) when pk in 0..65535, do: peer
 
   defp normalize_keepalive(%{persistent_keepalive: pk} = peer) do
-    Logger.warning("Ignoring invalid Wireguard peer PersistentKeepalive: #{inspect(pk)}")
+    Logger.warning(
+      "[VintageNetWireguard] Ignoring invalid peer PersistentKeepalive: #{inspect(pk)}"
+    )
+
     Map.delete(peer, :persistent_keepalive)
   end
 
@@ -135,7 +138,7 @@ defmodule VintageNetWireguard do
     do: peer
 
   defp normalize_preshared_key(%{preshared_key: psk} = peer) do
-    Logger.warning("Ignoring invalid Wireguard peer PresharedKey: #{inspect(psk)}")
+    Logger.warning("[VintageNetWireguard] Ignoring invalid peer PresharedKey: #{inspect(psk)}")
     Map.delete(peer, :preshared_key)
   end
 
@@ -216,7 +219,7 @@ defmodule VintageNetWireguard do
     else
       err ->
         Temp.cleanup()
-        {:error, "Failed to set Wireguard interface - #{inspect(err)}"}
+        {:error, "[VintageNetWireguard] Failed to set interface - #{inspect(err)}"}
     end
   end
 
@@ -248,7 +251,7 @@ defmodule VintageNetWireguard do
     else
       {err, s} ->
         Logger.error("""
-        Nonzero exit setting peer: #{s}
+        [VintageNetWireguard] Nonzero exit setting peer: #{s}
 
         #{inspect(err)}
         """)

--- a/lib/vintage_net_wireguard.ex
+++ b/lib/vintage_net_wireguard.ex
@@ -263,7 +263,7 @@ defmodule VintageNetWireguard do
   end
 
   defp add_peer_arg({:allowed_ips, v}, acc) do
-    addrs = Enum.map_join(v, " ", &addr_subnet/1)
+    addrs = Enum.map_join(v, ",", &addr_subnet/1)
     ["allowed-ips", addrs | acc]
   end
 


### PR DESCRIPTION
simple change from " " to "," in the `Enum.map_join/3` function to create a comma-separated list of IPs as expected by Wireguard