### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # VintageNetWireguard
 
 [![Hex version](https://img.shields.io/hexpm/v/vintage_net_wireguard.svg "Hex version")](https://hex.pm/packages/vintage_net_wireguard)
-[![API docs](https://img.shields.io/hexpm/v/vintage_net_wireguard.svg?label=hexdocs "API docs")](https://hexdocs.pm/vintage_net_wireguard/VintageNetWireguard.html)
+[![API docs](https://img.shields.io/hexpm/v/vintage_net_wireguard.svg?label=hexdocs "API docs")](https://vintage-net-wireguard.hexdocs.pm/VintageNetWireguard.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-networking/vintage_net_wireguard/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-networking/vintage_net_wireguard/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-networking/vintage_net_wireguard)](https://api.reuse.software/info/github.com/nerves-networking/vintage_net_wireguard)
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://vintage-net-wireguard.hexdocs.pm/VintageNetWireguard.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>